### PR TITLE
Fix byte-blob->blob to account for non-zero offset

### DIFF
--- a/byte-blob.scm
+++ b/byte-blob.scm
@@ -84,7 +84,13 @@
   )
 
 
-(define byte-blob->blob byte-blob-object)
+(define (byte-blob->blob b)
+  (if (zero? (byte-blob-offset b)) (byte-blob-object b)
+      (let* ((origblob (byte-blob-object b))
+	     (origlen  (byte-blob-length b))
+	     (newblob  (make-blob origlen)))
+	(move-memory! origblob newblob origlen (byte-blob-offset b) 0)
+	newblob)))
 
 (define (blob->byte-blob b)
   (and (blob? b) (make-byte-blob b 0 (blob-size b))))

--- a/tests/run.scm
+++ b/tests/run.scm
@@ -222,6 +222,12 @@
               (delete-file temp-path)
 	       
 	      )
+            ;; test case contributed by dthedens 
+            ;; Test for byte-blob->blob for non-zero offset
+            (test
+             (sprintf "byte-blob->blob for non-zero offset")
+             #${09}
+             (byte-blob->blob (byte-blob-drop c 2)))
 )
 
 	    


### PR DESCRIPTION
This is a proposed fix for issue 1 that I opened. This updates `byte-blob->blob` to create a new `blob` when the `byte-blob` has a non-zero offset to the beginning of the `byte-blob`. The code is essentially the same as that used in `byte-blob-take` to create a new `blob`. 

There is also a small test case to verify that the original reported problem related to mixing `byte-blob-drop` and `byte-blob->blob` is corrected. 